### PR TITLE
Updated handleResize() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,6 @@ cursor. Working examples are:
 - OSX Terminal
 - xfce4-terminal
 - terminator
+- kitty
+- ghostty
 

--- a/rain.c
+++ b/rain.c
@@ -96,7 +96,7 @@ void exitCurses();
 
 int pRand(int min, int max);
 int getNumOfDrops();
-void handleResize();
+void handleResize(int sig);
 void exitErr(const char *err);
 void usage();
 
@@ -270,7 +270,7 @@ int pRand(int min, int max)
     return min + rand() / (RAND_MAX / (max - min + 1) + 1);
 }
 
-void handleResize()
+void handleResize(int sig)
 {
     endwin();
 


### PR DESCRIPTION
The program could not compile since the handleResize() function was of type void func() but needed to be void func(int) to work with the signal() function from signal.h
And added kittu ang ghostty to supported terminals list